### PR TITLE
Improve training instrumentation and data loader throughput

### DIFF
--- a/configs/train_rbp_trna.yaml
+++ b/configs/train_rbp_trna.yaml
@@ -4,6 +4,12 @@ dataset_dir: data/processed/seq_cnn_v1_rbp_trna
 
 batch_size: 64
 num_workers: 8
+max_cache_shards: 2  # limit shard residency to control RAM usage per worker
+log_interval: 200
+dataloader_seed: 0
+prefetch_factor: 2
+persistent_workers: true
+log_level: INFO
 epochs: 20
 learning_rate: 1.5e-3
 weight_decay: 1.0e-4

--- a/src/side/dataset.py
+++ b/src/side/dataset.py
@@ -3,12 +3,79 @@
 from __future__ import annotations
 
 import json
+import logging
+from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, Iterable, List
 
+import numpy as np
 import pandas as pd
 import torch
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, Sampler, get_worker_info
+
+
+logger = logging.getLogger(__name__)
+
+
+class _ShardCache:
+    """LRU cache that keeps a limited number of shards resident in memory."""
+
+    def __init__(self, max_size: int) -> None:
+        if max_size < 1:
+            raise ValueError("max_size for shard cache must be at least 1")
+        self.max_size = max_size
+        self._store: "OrderedDict[int, Dict[str, torch.Tensor]]" = OrderedDict()
+
+    def get(self, key: int, loader: Callable[[], Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        if key in self._store:
+            value = self._store.pop(key)
+            self._store[key] = value
+            return value
+        value = loader()
+        self._store[key] = value
+        if len(self._store) > self.max_size:
+            evicted_key, _ = self._store.popitem(last=False)
+            logger.debug("Evicting shard %s from in-memory cache", evicted_key)
+        return value
+
+
+class ShardShuffleSampler(Sampler[int]):
+    """Sampler that randomises traversal order while keeping shard locality."""
+
+    def __init__(
+        self,
+        shard_groups: Iterable[np.ndarray],
+        *,
+        shuffle_within_shard: bool = True,
+        shuffle_shards: bool = True,
+        seed: int = 0,
+    ) -> None:
+        self._groups: List[np.ndarray] = [np.asarray(g, dtype=np.int64) for g in shard_groups if len(g) > 0]
+        if not self._groups:
+            raise ValueError("ShardShuffleSampler requires at least one non-empty shard group")
+        self.shuffle_within_shard = shuffle_within_shard
+        self.shuffle_shards = shuffle_shards
+        self._base_seed = seed
+        self._epoch = 0
+
+    def __len__(self) -> int:
+        return int(sum(len(group) for group in self._groups))
+
+    def set_epoch(self, epoch: int) -> None:
+        self._epoch = epoch
+
+    def __iter__(self):  # type: ignore[override]
+        rng = np.random.default_rng(self._base_seed + self._epoch)
+        shard_order = np.arange(len(self._groups))
+        if self.shuffle_shards:
+            rng.shuffle(shard_order)
+        for shard_idx in shard_order:
+            group = self._groups[shard_idx]
+            if self.shuffle_within_shard:
+                group = group.copy()
+                rng.shuffle(group)
+            for sample_idx in group:
+                yield int(sample_idx)
 
 
 def load_manifest(dataset_dir: str) -> Dict[str, Any]:
@@ -24,7 +91,13 @@ def load_manifest(dataset_dir: str) -> Dict[str, Any]:
 class UTRFeatureShardDataset(Dataset):
     """Dataset that streams UTR tensors from PyTorch shards with cached loading."""
 
-    def __init__(self, dataset_dir: str, split: str = "train") -> None:
+    def __init__(
+        self,
+        dataset_dir: str,
+        split: str = "train",
+        *,
+        max_cache_shards: int = 2,
+    ) -> None:
         self.dataset_dir = Path(dataset_dir)
         self.split = split
         self.shards_dir = self.dataset_dir / "shards"
@@ -36,7 +109,22 @@ class UTRFeatureShardDataset(Dataset):
         self.index = self._load_index(split)
         if {"part_id", "local_idx"} - set(self.index.columns):
             raise ValueError(f"Index for split '{split}' must contain part_id and local_idx")
-        self._cache: Dict[int, Dict[str, torch.Tensor]] = {}
+        self.index = self.index.reset_index(drop=True)
+        self._cache = _ShardCache(max_cache_shards)
+        grouped = self.index.groupby("part_id", sort=True).indices
+        self._shard_groups: List[np.ndarray] = [
+            np.asarray(list(indices), dtype=np.int64) for _, indices in sorted(grouped.items())
+        ]
+        if not self._shard_groups:
+            raise ValueError(f"Split '{split}' did not contain any samples")
+        self._max_cache_shards = max_cache_shards
+        logger.info(
+            "Initialised %s split with %d samples across %d shards (max_cache_shards=%d)",
+            split,
+            len(self.index),
+            len(self.shard_paths),
+            max_cache_shards,
+        )
 
     def _load_index(self, split: str) -> pd.DataFrame:
         candidates = [
@@ -56,18 +144,29 @@ class UTRFeatureShardDataset(Dataset):
         return int(len(self.index))
 
     def _load_shard(self, part_id: int) -> Dict[str, torch.Tensor]:
-        if part_id not in self._cache:
+        def _load() -> Dict[str, torch.Tensor]:
             shard_path = self.shard_paths[part_id]
+            worker = get_worker_info()
+            worker_id = worker.id if worker is not None else "main"
+            logger.info(
+                "Worker %s loading shard %s (%d/%d) with cache size %d",
+                worker_id,
+                shard_path.name,
+                part_id + 1,
+                len(self.shard_paths),
+                self._max_cache_shards,
+            )
             data = torch.load(shard_path, map_location="cpu")
             if not isinstance(data, dict):
                 raise ValueError(f"Shard {shard_path} must be a dict with tensors")
-            self._cache[part_id] = {
+            return {
                 "utr5": data["utr5"].float(),
                 "utr3": data["utr3"].float(),
                 "organ_id": data["organ_id"].long(),
                 "label": data["label"].float(),
             }
-        return self._cache[part_id]
+
+        return self._cache.get(part_id, _load)
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         row = self.index.iloc[idx]
@@ -79,3 +178,7 @@ class UTRFeatureShardDataset(Dataset):
         organ = shard["organ_id"][local_idx]
         label = shard["label"][local_idx]
         return {"utr5": utr5, "utr3": utr3, "organ_id": organ, "label": label}
+
+    @property
+    def shard_groups(self) -> List[np.ndarray]:
+        return self._shard_groups

--- a/src/side/train.py
+++ b/src/side/train.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
+import time
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -15,7 +17,11 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 import yaml
 
-from src.side.dataset import UTRFeatureShardDataset, load_manifest
+from src.side.dataset import (
+    ShardShuffleSampler,
+    UTRFeatureShardDataset,
+    load_manifest,
+)
 from src.side.model import DualBranchCNNFiLM
 
 
@@ -31,6 +37,9 @@ def setup_device() -> Tuple[torch.device, bool, int, int, int]:
     return device, distributed, rank, local_rank, world_size
 
 
+logger = logging.getLogger(__name__)
+
+
 def create_dataloaders(
     dataset_dir: str,
     batch_size: int,
@@ -38,11 +47,20 @@ def create_dataloaders(
     distributed: bool,
     rank: int,
     world_size: int,
+    *,
+    max_cache_shards: int,
+    shard_seed: int,
+    persistent_workers: bool,
+    prefetch_factor: int,
 ) -> Dict[str, DataLoader]:
     loaders: Dict[str, DataLoader] = {}
     for split in ("train", "val"):
         try:
-            dataset = UTRFeatureShardDataset(dataset_dir, split=split)
+            dataset = UTRFeatureShardDataset(
+                dataset_dir,
+                split=split,
+                max_cache_shards=max_cache_shards,
+            )
         except FileNotFoundError:
             if split == "val":
                 continue
@@ -55,14 +73,33 @@ def create_dataloaders(
                 rank=rank,
                 shuffle=(split == "train"),
             )
-        loaders[split] = DataLoader(
-            dataset,
+        elif split == "train":
+            sampler = ShardShuffleSampler(
+                dataset.shard_groups,
+                seed=shard_seed,
+            )
+        loader_kwargs = dict(
+            dataset=dataset,
             batch_size=batch_size,
             shuffle=(sampler is None and split == "train"),
             num_workers=num_workers,
             pin_memory=True,
             sampler=sampler,
         )
+        if num_workers > 0:
+            loader_kwargs["persistent_workers"] = persistent_workers
+            loader_kwargs["prefetch_factor"] = prefetch_factor
+        loaders[split] = DataLoader(**loader_kwargs)
+        if rank == 0:
+            num_batches = len(loaders[split])
+            logger.info(
+                "DataLoader[%s]: %d samples -> %d batches (batch_size=%d, workers=%d)",
+                split,
+                len(dataset),
+                num_batches,
+                batch_size,
+                num_workers,
+            )
     return loaders
 
 
@@ -79,6 +116,8 @@ def compute_r2(preds: np.ndarray, targets: np.ndarray) -> float:
 
 def run_training(cfg: Dict) -> None:
     device, distributed, rank, local_rank, world_size = setup_device()
+    if torch.cuda.is_available():
+        torch.backends.cudnn.benchmark = True
     dataset_dir = cfg["dataset_dir"]
     manifest = load_manifest(dataset_dir)
     organ_vocab = manifest.get("organ_vocab", {})
@@ -86,6 +125,16 @@ def run_training(cfg: Dict) -> None:
     if num_organs == 0:
         raise ValueError("Number of organs could not be determined from manifest or config")
     input_channels = manifest["shapes"]["utr5"][0]
+    if rank == 0:
+        logger.info(
+            "Starting training run | distributed=%s world_size=%d device=%s", distributed, world_size, device
+        )
+        logger.info(
+            "Detected %d organs (from manifest=%d, config=%d)",
+            num_organs,
+            len(organ_vocab),
+            int(cfg.get("num_organs", 0)),
+        )
     loaders = create_dataloaders(
         dataset_dir,
         batch_size=cfg.get("batch_size", 64),
@@ -93,6 +142,10 @@ def run_training(cfg: Dict) -> None:
         distributed=distributed,
         rank=rank,
         world_size=world_size,
+        max_cache_shards=cfg.get("max_cache_shards", 2),
+        shard_seed=cfg.get("dataloader_seed", 0),
+        persistent_workers=cfg.get("persistent_workers", True),
+        prefetch_factor=cfg.get("prefetch_factor", 2),
     )
     if "train" not in loaders:
         raise RuntimeError("Training split not found in dataset")
@@ -115,12 +168,24 @@ def run_training(cfg: Dict) -> None:
     best_r2 = -float("inf")
     best_state = None
     epochs = cfg.get("epochs", 20)
+    log_interval = max(int(cfg.get("log_interval", 200)), 1)
+    train_loader = loaders["train"]
+    train_sampler = getattr(train_loader, "sampler", None)
 
     for epoch in range(1, epochs + 1):
         model.train()
         train_loss = 0.0
         samples = 0
-        for batch in loaders["train"]:
+        epoch_start = time.perf_counter()
+        data_time_total = 0.0
+        iter_time_total = 0.0
+        if distributed and isinstance(train_sampler, DistributedSampler):
+            train_sampler.set_epoch(epoch)
+        elif hasattr(train_sampler, "set_epoch"):
+            train_sampler.set_epoch(epoch)
+        step_start = time.perf_counter()
+        for batch_idx, batch in enumerate(train_loader):
+            data_time = time.perf_counter() - step_start
             utr5 = batch["utr5"].to(device, non_blocking=True)
             utr3 = batch["utr3"].to(device, non_blocking=True)
             organ = batch["organ_id"].to(device, non_blocking=True)
@@ -132,14 +197,43 @@ def run_training(cfg: Dict) -> None:
             optimizer.step()
             train_loss += loss.item() * target.size(0)
             samples += target.size(0)
+            iter_time = time.perf_counter() - step_start
+            data_time_total += data_time
+            iter_time_total += iter_time
+            if rank == 0 and (batch_idx == 0 or (batch_idx + 1) % log_interval == 0):
+                batches_per_epoch = len(train_loader)
+                avg_iter = iter_time_total / (batch_idx + 1)
+                avg_data = data_time_total / (batch_idx + 1)
+                throughput = samples / max(iter_time_total, 1e-6)
+                logger.info(
+                    "Epoch %d/%d | step %d/%d | loss=%.4f | avg_iter=%.3fs | avg_data=%.3fs | samples/s=%.1f",
+                    epoch,
+                    epochs,
+                    batch_idx + 1,
+                    batches_per_epoch,
+                    loss.item(),
+                    avg_iter,
+                    avg_data,
+                    throughput,
+                )
+            step_start = time.perf_counter()
         train_loss /= max(samples, 1)
+        epoch_time = time.perf_counter() - epoch_start
         if rank == 0:
-            print(f"Epoch {epoch}/{epochs} - train loss: {train_loss:.4f}")
+            logger.info(
+                "Epoch %d/%d completed in %.2fs | train_loss=%.4f | samples=%d",
+                epoch,
+                epochs,
+                epoch_time,
+                train_loss,
+                samples,
+            )
 
         if "val" in loaders:
             model.eval()
             preds_all: List[float] = []
             labels_all: List[float] = []
+            val_start = time.perf_counter()
             with torch.no_grad():
                 for batch in loaders["val"]:
                     utr5 = batch["utr5"].to(device, non_blocking=True)
@@ -154,7 +248,8 @@ def run_training(cfg: Dict) -> None:
                 labels_arr = np.concatenate(labels_all)
                 r2 = compute_r2(preds_arr, labels_arr)
                 if rank == 0:
-                    print(f"  Validation R2: {r2:.4f}")
+                    val_time = time.perf_counter() - val_start
+                    logger.info("Validation completed in %.2fs | R2=%.4f", val_time, r2)
                 if r2 > best_r2 and rank == 0:
                     best_r2 = r2
                     best_state = {k: v.cpu() for k, v in model.state_dict().items()}
@@ -163,17 +258,25 @@ def run_training(cfg: Dict) -> None:
         out_path = Path(cfg.get("output_model_path", "outputs/best_model.pt"))
         out_path.parent.mkdir(parents=True, exist_ok=True)
         torch.save(best_state, out_path)
-        print(f"Saved best model to {out_path} (R2={best_r2:.4f})")
+        logger.info("Saved best model to %s (best R2=%.4f)", out_path, best_r2)
     if distributed:
         dist.destroy_process_group()
 
 
 def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
     parser = argparse.ArgumentParser(description="Train the FiLM CNN with UTR features")
     parser.add_argument("--config", required=True, help="Path to YAML configuration")
     args = parser.parse_args()
     with open(args.config, "r", encoding="utf-8") as fh:
         cfg = yaml.safe_load(fh)
+    log_level = cfg.get("log_level")
+    if log_level:
+        logging.getLogger().setLevel(getattr(logging, str(log_level).upper(), logging.INFO))
+    logger.info("Loaded training configuration from %s", args.config)
     run_training(cfg)
 
 


### PR DESCRIPTION
## Summary
- add shard-aware sampler and bounded shard cache to the UTR dataset to stabilise multi-worker loading
- expose new dataloader and logging controls via the training configuration file
- instrument the training loop with detailed progress, timing metrics, and validation reporting

## Testing
- python -m compileall src/side

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124afcf3048322abcdd7b6f1ebb3d5)