### PR TITLE
Align evaluation macro R2 and enable file logging

### DIFF
--- a/configs/train_rbp_trna.yaml
+++ b/configs/train_rbp_trna.yaml
@@ -10,6 +10,7 @@ dataloader_seed: 0
 prefetch_factor: 2
 persistent_workers: true
 log_level: INFO
+log_file: /tmp/side_train_rbp_trna.log
 epochs: 20
 learning_rate: 1.5e-3
 weight_decay: 1.0e-4


### PR DESCRIPTION
## Summary
- align the validation R² computation with the cnn_v1 macro-averaged implementation
- add optional file logging support that defaults to a timestamped /tmp path for rank 0
- expose the new log_file configuration on the RBP/tRNA training config for convenience

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912deef4dd48322b1654cd57c1f46dd)